### PR TITLE
Relax molecule upper version bound

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ setup_requires =
     setuptools_scm_git_archive
 install_requires =
     hcloud >= 1.10.0, < 2
-    molecule >= 3.2.1, <= 3.3
+    molecule >= 3.2.1, < 4
     pyyaml >= 5.3.1, < 6
 
 [options.extras_require]


### PR DESCRIPTION
The Hetzner driver set the Molecule version bound at 3.3.0, which makes it impossible to use it with the next stable version of Molecule.

Changes in this commit move the upper bound to 4.0.0, which is the first version of Molecule that can introduce backward-incompatible changes into its API.

Sample failure: https://github.com/ansible-community/molecule/pull/3085/checks?check_run_id=2213869231