### PR TITLE
Remove async for network deletion

### DIFF
--- a/molecule_hetznercloud/cookiecutter/scenario/driver/hetznercloud/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
+++ b/molecule_hetznercloud/cookiecutter/scenario/driver/hetznercloud/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/destroy.yml
@@ -67,17 +67,6 @@
         state: absent
       register: networks
       loop: "{{ instance_conf|subelements('networks', skip_missing=True) }}"
-      async: 7200
-      poll: 0
-
-    - name: Wait for network(s) deletion to complete
-      async_status:
-        jid: "{{ item.ansible_job_id }}"
-      register: hetzner_networks
-      until: hetzner_networks.finished
-      retries: 300
-      when: networks.changed
-      with_items: "{{ networks.results }}"
 
     - name: Remove registered SSH key
       hcloud_ssh_key:

--- a/molecule_hetznercloud/playbooks/destroy.yml
+++ b/molecule_hetznercloud/playbooks/destroy.yml
@@ -63,17 +63,6 @@
         state: absent
       register: networks
       loop: "{{ instance_conf|subelements('networks', skip_missing=True) }}"
-      async: 7200
-      poll: 0
-
-    - name: Wait for network(s) deletion to complete
-      async_status:
-        jid: "{{ item.ansible_job_id }}"
-      register: hetzner_networks
-      until: hetzner_networks.finished
-      retries: 300
-      when: networks.changed
-      with_items: "{{ networks.results }}"
 
     - name: Remove registered SSH key
       hcloud_ssh_key:

--- a/molecule_hetznercloud/test/resources/playbooks/hetznercloud/destroy.yml
+++ b/molecule_hetznercloud/test/resources/playbooks/hetznercloud/destroy.yml
@@ -66,17 +66,6 @@
         state: absent
       register: networks
       loop: "{{ instance_conf|subelements('networks', skip_missing=True) }}"
-      async: 7200
-      poll: 0
-
-    - name: Wait for network(s) deletion to complete
-      async_status:
-        jid: "{{ item.ansible_job_id }}"
-      register: hetzner_networks
-      until: hetzner_networks.finished
-      retries: 300
-      when: networks.changed
-      with_items: "{{ networks.results }}"
 
     - name: Remove registered SSH key
       hcloud_ssh_key:


### PR DESCRIPTION
Hi, quick bug fix..
It seems like the async deletion of Networks is extremely unreliable and will often fail in some scenarios. I had one of those scenarios right now and think it is better to leave async out for this task. 
Because of the async ansible tries to delete a network which is not longer existing. 