### PR TITLE
Handle case of absent instance_config.yml gracefully

### DIFF
--- a/molecule_hetznercloud/playbooks/destroy.yml
+++ b/molecule_hetznercloud/playbooks/destroy.yml
@@ -6,16 +6,16 @@
   no_log: "{{ molecule_no_log }}"
   tasks:
     - name: Populate the instance config
-      block:
-        - name: Populate instance config from file
-          set_fact:
-            instance_conf: "{{ lookup('file', molecule_instance_config) | from_yaml }}"
-            skip_instances: false
-      rescue:
-        - name: Populate instance config when file missing
-          set_fact:
-            instance_conf: {}
-            skip_instances: true
+      set_fact:
+        instance_conf: "{{ lookup('file', molecule_instance_config, errors='warn') | from_yaml }}"
+        skip_instances: false
+      register: instance_config_lookup
+
+    - name: Populate instance config when file missing
+      set_fact:
+        instance_conf: {}
+        skip_instances: true
+      when: not instance_config_lookup.ansible_facts.instance_conf
 
     - name: Destroy molecule instance(s)
       hcloud_server:


### PR DESCRIPTION
i.e., instead of throwing a red fatal error message at the user and recovering with a rescue block we downgrade the lookup error to a warning and set the same defaults in that case that were set in the rescue block before.

happy path:

```
PLAY [Destroy] *****************************************************************

TASK [Populate the instance config] ********************************************
ok: [localhost]

TASK [Populate instance config when file missing] ******************************
skipping: [localhost]
```

failed lookup case (the debug statements were just added to demonstrate the change of facts):

```
PLAY [Destroy] *****************************************************************

TASK [Populate the instance config] ********************************************
[WARNING]: Unable to find 'foo.yml' in expected paths (use -vvvvv to see paths)
[WARNING]: An unhandled exception occurred while running the lookup plugin
'file'. Error was a <class 'ansible.errors.AnsibleError'>, original message:
could not locate file in lookup: foo.yml
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "instance_conf": ""
}

TASK [debug] *******************************************************************
ok: [localhost] => {
    "skip_instances": false
}

TASK [Populate instance config when file missing] ******************************
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "instance_conf": {}
}

TASK [debug] *******************************************************************
ok: [localhost] => {
    "skip_instances": true
}
```

This fixes one aspect of #31 .