### PR TITLE
Remove deprecated molecule cache

### DIFF
--- a/molecule_hetznercloud/driver.py
+++ b/molecule_hetznercloud/driver.py
@@ -1,8 +1,9 @@
 import os
 
+from ansible_compat.ports import cache
 from molecule import logger, util
 from molecule.api import Driver
-from molecule.util import lru_cache, sysexit_with_message
+from molecule.util import sysexit_with_message
 
 log = logger.get_logger(__name__)
 
@@ -75,7 +76,7 @@ class HetznerCloud(Driver):
             item for item in instance_config_dict if item["instance"] == instance_name
         )
 
-    @lru_cache()
+    @cache
     def sanity_checks(self):
         """Hetzner Cloud driver sanity checks."""
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ setup_requires =
     setuptools_scm
     setuptools_scm_git_archive
 install_requires =
+    ansible-compat >= 0.5.0
     hcloud >= 1.10.0, < 2
     molecule >= 3.2.1, < 4
     pyyaml >= 5.3.1, < 6


### PR DESCRIPTION
This makes the driver version with future versions of molecule,
which will no longer have the cache in them. Same kind of change
was already merged in two other drivers podman and docker.

Related: https://github.com/ansible-community/molecule/pull/3180