### PR TITLE
Remove dependency ceiling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,21 +55,23 @@ setup_requires =
     setuptools_scm
     setuptools_scm_git_archive
 install_requires =
+    # do not use ceiling unless you already know that newer version breaks
+    # do not use pre-release versions
     ansible-compat >= 0.5.0
-    hcloud >= 1.10.0, < 2
-    molecule >= 3.2.1, < 4
-    pyyaml >= 5.3.1, < 6
+    hcloud >= 1.10.0
+    molecule >= 3.2.1
+    pyyaml >= 5.3.1
 
 [options.extras_require]
 test =
-    hcloud >= 1.10.0, < 2
-    mock >= 4.0.2, < 5
-    pytest-cov >= 2.10.1, < 3
-    pytest-helpers-namespace >= 2019.1.8, < 2020
-    pytest-mock >= 3.5.0, < 4
-    pytest-verbose-parametrize>=1.7.0, < 2
-    pytest-xdist>=2.2.0, < 3
-    pytest>=6.2.1, < 7
+    hcloud >= 1.10.0
+    mock >= 4.0.2
+    pytest-cov >= 2.10.1
+    pytest-helpers-namespace >= 2019.1.8
+    pytest-mock >= 3.5.0
+    pytest-verbose-parametrize>=1.7.0
+    pytest-xdist>=2.2.0
+    pytest>=6.2.1
 
 [options.packages.find]
 where = .


### PR DESCRIPTION
Ceiling caused installation conflicts with newer versions of
molecule. We should avoid them until we discover that a newer version
effectively breaks us.