### PR TITLE
ci: use tps-token to run integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
     name: Integration Python ${{ matrix.python-version }}
     steps:
       - uses: hetznercloud/tps-action@main
+        with:
+          tps-token: ${{ secrets.TPS_TOKEN }}
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Use a tps-token in addition to the OIDC tokens for the integration tests. 