### PR TITLE
ci: use oidc tokens to publish packages to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: python3 -m build
 
       - name: Check
-        run: twine check dist/*
+        run: twine check --strict dist/*
 
       - name: Upload packages artifact
         if: github.event_name == 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,30 @@ jobs:
       - name: Check
         run: twine check dist/*
 
-      - name: Publish
+      - name: Upload packages artifact
         if: github.event_name == 'release'
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload dist/*
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-packages
+          path: dist/
+
+  publish:
+    if: github.event_name == 'release'
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/molecule-hetznercloud
+    permissions:
+      id-token: write
+
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Download packages artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: python-packages
+          path: dist/
+
+      - name: Publish packages to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.10


### PR DESCRIPTION
Closes #48 