### PR TITLE
feat: allow user defined RESOURCE_NAMESPACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ $ export MOLECULE_NO_LOG=False  # not so verbose, helpful
 $ export MOLECULE_DEBUG=True  # very verbose, last ditch effort
 ```
 
+You may also define a custom resource namespace by exposing the following
+environment variables, for example in CI workflows:
+
+```bash
+$ export RESOURCE_NAMESPACE=e121dc64ff615ccdfac71bb5c00296b9 # Ensure the value length is <= 32
+```
+
 ## Development
 
 ### Testing

--- a/molecule_hetznercloud/playbooks/create.yml
+++ b/molecule_hetznercloud/playbooks/create.yml
@@ -5,7 +5,7 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   vars:
-    resource_namespace: "{{ molecule_scenario_directory | md5 }}"
+    resource_namespace: "{{ lookup('ansible.builtin.env', 'RESOURCE_NAMESPACE') | default(molecule_scenario_directory | md5, true) }}"
 
     ssh_port: 22
     ssh_user: root

--- a/molecule_hetznercloud/playbooks/destroy.yml
+++ b/molecule_hetznercloud/playbooks/destroy.yml
@@ -5,7 +5,7 @@
   gather_facts: false
   no_log: "{{ molecule_no_log }}"
   vars:
-    resource_namespace: "{{ molecule_scenario_directory | md5 }}"
+    resource_namespace: "{{ lookup('ansible.builtin.env', 'RESOURCE_NAMESPACE') | default(molecule_scenario_directory | md5, true) }}"
   tasks:
     - name: Populate the instance config
       ansible.builtin.set_fact:


### PR DESCRIPTION
If the uniqueness of `molecule_scenario_directory` is not enough, one can override the RESOURCE_NAMESPACE variable to provide their own value. For example, this can prevent collisions with duplicate CI workflows.