### PR TITLE
chore: ignore CHANGELOG.md format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
     hooks:
       - id: prettier
         files: \.(md|ya?ml)$
+        exclude: ^CHANGELOG\.md$
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0


### PR DESCRIPTION
Prevent some repetitive pre-commit ci  auto fixing commits.