### PR TITLE
feat: change the generated ssh key type to `ed25519`

### DIFF
--- a/molecule_hetznercloud/playbooks/create.yml
+++ b/molecule_hetznercloud/playbooks/create.yml
@@ -15,6 +15,7 @@
     - name: Create SSH key
       community.crypto.openssh_keypair:
         path: "{{ ssh_key_path }}"
+        type: ed25519
       register: generated_ssh_key
 
     - name: Register SSH key for server(s)


### PR DESCRIPTION
Implements #68

Based on https://www.openssh.com/txt/release-8.7 (in the Imminent deprecation notice section)