### PR TITLE
feat: instance `server_type` now defaults to `cx22`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ $ pip install --upgrade molecule-hetznercloud
 
 - Each resource (servers, volumes, networks) name are prefixed with a hash (32 chars) based on the role and scenario path. This means you MAY reuse the same names (e.g. `instance-1`) across your scenarios. Resource names MUST not exceed their max length, for example the server name max length is 63 chars, with the prefix you only have 31 chars left for your name.
 
-- In your `molecule.yml` files, the platforms server type (`platforms[].server_type`) field now defaults to `cx11`. If you already use the default, you MAY remove the field:
+- In your `molecule.yml` files, the platforms server type (`platforms[].server_type`) field now defaults to `cx22`. If you already use the default, you MAY remove the field:
 
 ```patch
  platforms:
    - name: instance-1
      image: debian-12
--    server_type: cx11
+-    server_type: cx22
 ```
 
 ## Usage
@@ -87,8 +87,8 @@ platforms:
     # required
     image: debian-12
     # Name of the Server type this Server should be created with.
-    # default: cx11
-    server_type: cx11
+    # default: cx22
+    server_type: cx22
     # Name of Location to create Server in (must not be used together with datacenter).
     # default: omit
     location: hel1

--- a/molecule_hetznercloud/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule_hetznercloud/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -9,8 +9,8 @@ platforms:
     # required
     image: debian-12
     # Name of the Server type this Server should be created with.
-    # default: cx11
-    server_type: cx11
+    # default: cx22
+    server_type: cx22
     # Name of Location to create Server in (must not be used together with datacenter).
     # default: omit
     location: hel1

--- a/molecule_hetznercloud/playbooks/create.yml
+++ b/molecule_hetznercloud/playbooks/create.yml
@@ -30,7 +30,7 @@
       hetzner.hcloud.hcloud_server:
         name: "{{ resource_namespace }}-{{ item.name }}"
         image: "{{ item.image }}"
-        server_type: "{{ item.server_type | default('cx11') }}"
+        server_type: "{{ item.server_type | default('cx22') }}"
         ssh_keys: ["{{ ssh_key_name }}"]
         location: "{{ item.location | default(omit) }}"
         datacenter: "{{ item.datacenter | default(omit) }}"


### PR DESCRIPTION
Learn more: https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated

- Updated docs with newer server types
- Update default server type to use newer server type