### PR TITLE
feat: require python>=3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     permissions:
       id-token: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     rev: v3.16.0
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/setup.py
+++ b/setup.py
@@ -38,14 +38,13 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Topic :: System :: Systems Administration",
         "Topic :: Utilities",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=[
         "molecule>=5.0.0,<24.8",
         # Dependencies for the hetzner.hcloud collection

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 [tox]
 min_version = 4.0
 env_list =
-    py{39,310,311,312}-molecule{5,6}
+    py{310,311,312}-molecule{5,6}
     py{310,311,312}-molecule24
 
 [testenv]
@@ -23,7 +23,6 @@ passenv =
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
Many Ansible development tools dropped earlier version of python. We are following the trend.