### PR TITLE
test: run with ansible-core <2.18

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     molecule5: molecule>=5.0,<6
     molecule6: molecule>=6.0,<7
     molecule24: molecule>=24.0,<25
-    ansible-core>=2.13,<2.17
+    ansible-core>=2.13,<2.18
 commands =
     pytest -v {posargs}
 passenv =


### PR DESCRIPTION
Bump the ansible-core test dependency.