### PR TITLE
test: run against latest version of molecule

### DIFF
--- a/tests/functional/test_hetznercloud.py
+++ b/tests/functional/test_hetznercloud.py
@@ -5,7 +5,14 @@ from shutil import copytree
 
 import pytest
 from molecule._version import version_tuple as molecule_version_tuple
-from molecule.util import run_command
+
+if molecule_version_tuple < (25, 1):
+    from molecule.util import run_command
+else:
+    from molecule.app import get_app
+
+    run_command = get_app(Path()).run_command
+
 
 import molecule_hetznercloud
 

--- a/tests/integration/molecule/default/converge.yml
+++ b/tests/integration/molecule/default/converge.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Include integration
-      ansible.builtin.include_role:
-        name: integration
+    - name: Debug output
+      ansible.builtin.debug:
+        msg: "{{ ansible_hostname }}"

--- a/tests/integration/tasks/main.yml
+++ b/tests/integration/tasks/main.yml
@@ -1,4 +1,0 @@
----
-- name: Debug output
-  ansible.builtin.debug:
-    msg: "{{ ansible_hostname }}"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 min_version = 4.0
 env_list =
     py{310,311,312}-molecule{5,6}
-    py{310,311,312}-molecule24
+    py{310,311,312}-molecule
 
 [testenv]
 usedevelop = True
@@ -11,7 +11,7 @@ extras = test
 deps =
     molecule5: molecule>=5.0,<6
     molecule6: molecule>=6.0,<7
-    molecule24: molecule>=24.0,<25
+    molecule: molecule>=24.0
     ansible-core>=2.13,<2.18
 commands =
     pytest -v {posargs}


### PR DESCRIPTION
We should follow the behavior introduced in #136 for our tests.