### PR TITLE
ci: add missing path to releaser-pleaser

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,3 +22,4 @@ jobs:
           token: ${{ secrets.HCLOUD_BOT_TOKEN }}
           extra-files: |
             molecule_hetznercloud/_version.py
+            setup.py


### PR DESCRIPTION
The setup.py path was missing to allow bumping the version in setup.py.