### PR TITLE
feat: drop support for molecule v5 and v6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,16 +2,13 @@
 [tox]
 min_version = 4.0
 env_list =
-    py{310,311,312,313}-molecule{5,6}
-    py{310,311,312,313}-molecule
+    py{310,311,312,313}
 
 [testenv]
 usedevelop = True
 extras = test
 deps =
-    molecule5: molecule>=5.0,<6
-    molecule6: molecule>=6.0,<7
-    molecule: molecule>=24.0
+    molecule>=24.0
     ansible-core>=2.13
 commands =
     pytest -v {posargs}


### PR DESCRIPTION
The driver can still be used with those older molecule versions, but we will not longer test them in our CI.

Please consider upgrading your molecule version.