### PR TITLE
feat: set server-type default to cx23

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ platforms:
     # required
     image: debian-12
     # Name of the Server type this Server should be created with.
-    # default: cx22
-    server_type: cx22
+    # default: cx23
+    server_type: cx23
     # Name of Location to create Server in (must not be used together with datacenter).
     # default: omit
     location: hel1

--- a/molecule_hetznercloud/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/molecule_hetznercloud/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/molecule.yml
@@ -9,8 +9,8 @@ platforms:
     # required
     image: debian-12
     # Name of the Server type this Server should be created with.
-    # default: cx22
-    server_type: cx22
+    # default: cx23
+    server_type: cx23
     # Name of Location to create Server in (must not be used together with datacenter).
     # default: omit
     location: hel1

--- a/molecule_hetznercloud/playbooks/create.yml
+++ b/molecule_hetznercloud/playbooks/create.yml
@@ -30,7 +30,7 @@
       hetzner.hcloud.hcloud_server:
         name: "{{ resource_namespace }}-{{ item.name }}"
         image: "{{ item.image }}"
-        server_type: "{{ item.server_type | default('cx22') }}"
+        server_type: "{{ item.server_type | default('cx23') }}"
         ssh_keys: ["{{ ssh_key_name }}"]
         location: "{{ item.location | default(omit) }}"
         datacenter: "{{ item.datacenter | default(omit) }}"


### PR DESCRIPTION
The current default [cx22 was deprecated and will be removed on 2026-01-01](https://docs.hetzner.cloud/changelog#2025-10-16-server-types-deprecated).