### PR TITLE
docs: migrate RTD URLs to docs.ansible.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Codecov](https://img.shields.io/codecov/c/github/ansible-community/molecule-hetznercloud/main)](https://app.codecov.io/gh/ansible-community/molecule-hetznercloud/tree/main)
 [![License](https://img.shields.io/badge/license-LGPL-brightgreen.svg)](LICENSE)
 
-A [Hetzner Cloud](https://www.hetzner.com/cloud) driver for [Molecule](https://ansible.readthedocs.io/projects/molecule/).
+A [Hetzner Cloud](https://www.hetzner.com/cloud) driver for [Molecule](https://docs.ansible.com/projects/molecule/).
 
 This plugin allows you to use on-demand Hetzner Cloud servers for your molecule integration tests.
 


### PR DESCRIPTION
## Summary

This PR updates `readthedocs.io` URLs to their `docs.ansible.com` equivalents with proper anchor preservation.

## Changes (1 unique URLs, 1 files updated)

- https://ansible.readthedocs.io/projects/molecule/ → https://docs.ansible.com/projects/molecule/

## Technical Details

- ✅ Anchor fragments preserved during URL transformations
- ✅ HTTP redirects followed to final destinations  
- ✅ URL validation completed before applying changes
- ✅ Configuration-driven URL mapping system

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>