### PR TITLE
feat: platforms `datacenter` config was removed, use `location` instead

### DIFF
--- a/molecule_hetznercloud/driver.json
+++ b/molecule_hetznercloud/driver.json
@@ -35,9 +35,6 @@
             "location": {
               "type": "string"
             },
-            "datacenter": {
-              "type": "string"
-            },
             "user_data": {
               "type": "string"
             },

--- a/molecule_hetznercloud/playbooks/create.yml
+++ b/molecule_hetznercloud/playbooks/create.yml
@@ -33,7 +33,6 @@
         server_type: "{{ item.server_type | default('cx23') }}"
         ssh_keys: ["{{ ssh_key_name }}"]
         location: "{{ item.location | default(omit) }}"
-        datacenter: "{{ item.datacenter | default(omit) }}"
         user_data: "{{ item.user_data | default(omit) }}"
         labels:
           molecule: "{{ resource_namespace }}"


### PR DESCRIPTION
The deprecated `datacenter` config was removed. Since the property was already removed from the Hetzner Cloud API, we do not consider this a breaking change (see [changelog entry](https://docs.hetzner.cloud/changelog#2026-07-01-removing-datacenters)).

- https://docs.hetzner.cloud/changelog#2026-07-01-removing-datacenters
- https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters